### PR TITLE
Add support for wildcards

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ Notes
 4. ERB tags will be evaluated in all YAML files.
 5. The `extends` option can use either a single file string, or an array. 
    Extensions are optional.
-6. If you need to use a key that is named differently, provide it using the
-   `key` keyword argument:
+6. Using `*` anywhere in the `extends` path will load multiple files with one
+   call.
+7. If you need to use a key that is named differently than `extends`, provide
+   it using the `key` keyword argument:
    ```ruby
    ExtendedYAML.load 'examples/simple.yml', key: 'include'
    ```

--- a/examples/master.yml
+++ b/examples/master.yml
@@ -1,9 +1,14 @@
 # Load this file with
 #
 #   ExtendedYAML.load 'master.yml'
+
+# The `extends` key defines additional files to load
 #
-# Merge in other files (extension is optional).
-# Path is relative to the location of the YAML file.
+# - Path is relative to the location of the YAML file.
+# - This can be either an array or a single string.
+# - Extension is optional.
+# - Using * anywhere in the path will trigger a glob search and load all
+#   matching files.
 extends:
 - subdir/array
 - subdir/hash.yml

--- a/examples/wildcard.yml
+++ b/examples/wildcard.yml
@@ -1,0 +1,13 @@
+# Load this file with
+#
+#   ExtendedYAML.load 'wildcard.yml'
+#
+# Use * to trigger a wildcard import and load all the matching files.
+# Extension is optional in all cases.
+extends:
+- subdir/production.yml
+- wildcard/*
+
+settings:
+  host: localhost
+  port: 80

--- a/examples/wildcard/1.yml
+++ b/examples/wildcard/1.yml
@@ -1,0 +1,2 @@
+imported_from_one: true
+override: one

--- a/examples/wildcard/2.yml
+++ b/examples/wildcard/2.yml
@@ -1,0 +1,2 @@
+imported_from_two: true
+override: two

--- a/spec/approvals/wildcard.yml
+++ b/spec/approvals/wildcard.yml
@@ -1,0 +1,7 @@
+---
+settings:
+  host: example.com
+  port: 80
+imported_from_one: true
+override: two
+imported_from_two: true

--- a/spec/extended_yaml/extended_yaml_spec.rb
+++ b/spec/extended_yaml/extended_yaml_spec.rb
@@ -3,16 +3,25 @@ require 'yaml'
 
 describe ExtendedYAML do
   describe '::load' do
-    subject { ExtendedYAML.load 'examples/master.yml' }
+    subject { described_class.load 'examples/master.yml' }
 
     it "loads and evaluates a YAML file" do
       expect(subject.to_yaml).to match_fixture('master.yml')
     end
 
     context "when a different key is provided" do
-      subject { ExtendedYAML.load 'examples/different_key.yml', key: 'include' }
+      subject { described_class.load 'examples/different_key.yml', key: 'include' }
+
       it "uses that key to load additional YAML files" do
         expect(subject.to_yaml).to match_fixture('different_key.yml')
+      end
+    end
+
+    context "when using wildcards" do
+      subject { described_class.load 'examples/wildcard.yml' }
+
+      it "imports all files" do
+        expect(subject.to_yaml).to match_fixture('wildcard.yml')
       end
     end
   end


### PR DESCRIPTION
This PR makes it possible to do any of these:

```yaml
extends: some_path/*

extends: some_path/**/*

extends:
- some_path/*
- some_other_path/**/*
```

As with regular filenames, extension is optional and will be inferred from the extension (.yaml/.yml) of the source file.