### PR TITLE
Fix loading of empty files

### DIFF
--- a/lib/extended_yaml.rb
+++ b/lib/extended_yaml.rb
@@ -17,10 +17,10 @@ class ExtendedYAML
     @file, @key = file, key
   end
 
-  # @return [Hash, Array] the parsed YAML
+  # @return [Hash, Array, nil] the parsed YAML
   def result
     data = ::YAML.load evaluate
-    resolve_extends data
+    data ? resolve_extends(data) : nil
   end
 
   # @return [String] the YAML string, with evaluated and ERB

--- a/spec/extended_yaml/extended_yaml_spec.rb
+++ b/spec/extended_yaml/extended_yaml_spec.rb
@@ -34,5 +34,21 @@ describe ExtendedYAML do
         expect(subject.to_yaml).to match_fixture('wildcard.yml')
       end
     end
+
+    context "with an invalid path" do
+      subject { described_class.load 'no-such-file.yml' }
+
+      it "raises Errno::ENOENT" do
+        expect { subject }.to raise_error(Errno::ENOENT, /No such file or directory/)
+      end
+    end
+
+    context "with an empty file" do
+      subject { described_class.load 'spec/fixtures/empty.yml' }
+
+      it "returns nil" do
+        expect(subject).to be_nil
+      end
+    end
   end
 end

--- a/spec/fixtures/empty.yml
+++ b/spec/fixtures/empty.yml
@@ -1,0 +1,1 @@
+# empty file


### PR DESCRIPTION
Loading empty YAML files caused an error so:

1. It will now return nil instead of crashing
2. Added tests for empty file and for invalid path

This problem was noticeable in Sting, when adding multiple files together and some of them (for example some `settings.local.yml`) was empty.